### PR TITLE
Fix OpenAPI schema generation for individual response types

### DIFF
--- a/pkg/core/app.go
+++ b/pkg/core/app.go
@@ -313,7 +313,7 @@ func (a App) addFuncToOpenApiGen(gen *openapi.Generator, route Route, endPoint E
 
 	objInType := reflect.TypeOf(endPoint.routeOptionConfig.ObjIn)
 	objOutType := reflect.TypeOf(endPoint.routeOptionConfig.ObjOut)
-	errResType := reflect.TypeOf(&ErrorResponse{})
+	errResType := reflect.TypeOf(ErrorResponse{})
 
 	newEndpointBuilder := openapi.NewEndpointBuilder().
 		Summary("Default Summary").

--- a/pkg/openapi/generator.go
+++ b/pkg/openapi/generator.go
@@ -188,11 +188,23 @@ func (g *Generator) GenerateSpec() (*OpenAPISpec, error) {
 				builder.options.RequestBody.Schema = &schema
 			}
 
+			// Generate schemas for individual response types
+			for statusCode, response := range builder.options.Responses {
+				if response.Type != nil {
+					schema := g.schemaGenerator.GenerateSchema(response.Type)
+					response.Schema = &schema
+					builder.options.Responses[statusCode] = response
+				}
+			}
+
+			// Fallback: if ResponseType is set, apply it to responses without specific types
 			if options.ResponseType != nil {
 				schema := g.schemaGenerator.GenerateSchema(options.ResponseType)
 				for statusCode, response := range builder.options.Responses {
-					response.Schema = &schema
-					builder.options.Responses[statusCode] = response
+					if response.Schema == nil {
+						response.Schema = &schema
+						builder.options.Responses[statusCode] = response
+					}
 				}
 			}
 


### PR DESCRIPTION
## Problem
The OpenAPI generator was not generating schemas for individual response types (like `ErrorResponse`) for error status codes (400, 422, 500). Instead, it was applying a single `ResponseType` schema to all responses, which meant error responses didn't get proper schema definitions in the generated OpenAPI specification.

This resulted in Swagger UI not displaying proper documentation for error responses, making the API documentation incomplete.

## Root Cause
In `pkg/openapi/generator.go`, the `GenerateSpec` method was:
1. Only generating a schema for `options.ResponseType` (typically nil)
2. Applying the same schema to all responses regardless of their individual `Type` field
3. Ignoring the specific `response.Type` field for each response

## Solution
Fixed the `GenerateSpec` method to:
- **Generate schemas for individual response types**: Iterate through each response and generate a schema for its specific `Type` field
- **Preserve fallback behavior**: Keep the original `ResponseType` logic as a fallback for responses without specific types
- **Fix pointer type usage**: Changed `pkg/core/app.go` to use `reflect.TypeOf(ErrorResponse{})` instead of `reflect.TypeOf(&ErrorResponse{})` for consistency

## Changes Made

### 1. `pkg/openapi/generator.go`
- Replaced single `ResponseType` processing with individual response type processing
- Added fallback logic to maintain backward compatibility
- Now generates proper schemas for each response's `Type` field

### 2. `pkg/core/app.go`
- Changed from pointer type `&ErrorResponse{}` to value type `ErrorResponse{}` for reflection
- Ensures consistent schema generation

### 3. Added comprehensive tests
- Created `pkg/openapi/response_schema_test.go` with tests to verify:
  - Individual response type schema generation
  - Proper schema references in OpenAPI spec
  - Pointer type handling

## Expected Results
After this fix:
- ✅ **ErrorResponse schema** will be generated and included in `components/schemas`
- ✅ **Error responses** (400, 422, 500) will have proper schema references like `#/components/schemas/ErrorResponse`
- ✅ **Swagger UI** will display proper schema documentation for error responses
- ✅ **Multiple response types** will each get their own schema definitions

## Testing
To test the fix using nix dev-shell:
```bash
nix develop
cd pkg/openapi/demo
go run main.go
# Check generated docs/openapi.json for ErrorResponse schema
# Open docs/index.html in browser to see Swagger UI
```

Run tests:
```bash
go test ./pkg/openapi/...
```

## Backward Compatibility
This fix is fully backward compatible. It enhances the existing functionality without breaking any existing behavior.

## Files Modified
- `pkg/openapi/generator.go` - Fixed schema generation logic
- `pkg/core/app.go` - Fixed ErrorResponse type reflection  
- `pkg/openapi/response_schema_test.go` - Added comprehensive tests
- `OPENAPI_FIX_SUMMARY.md` - Added detailed documentation

Fixes the issue where ErrorResponse and other response schemas were not being generated for error responses in the OpenAPI specification.

@Bata94 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d14fecb87ce342b18475fa03b9d72bc0)